### PR TITLE
Use params attribute of requests.Session

### DIFF
--- a/etherscan/account.py
+++ b/etherscan/account.py
@@ -5,23 +5,21 @@ class Account(Client):
 
     def __init__(self, address, api_key = ''):
         super().__init__(address, api_key = api_key)
-        self.url_dict[self.MODULE] = 'account'
+        self.set_query_param(module='account')
 
     def get_balance(self) -> int:
         '''Get the latest balance on address.'''
-        self.url_dict[self.ACTION] = 'balance'
-        self.url_dict[self.TAG] = 'latest'
+        self.set_query_param(action='balance')
+        self.set_query_param(tag='latest')
 
-        self.build_url()
         req = self.connect()
         return req['result']
 
     def get_transaction_page(self) -> list:
         '''Get the latest transactions on address'''
-        self.url_dict[self.ACTION] = 'txlist'
-        self.url_dict[self.SORT] = 'desc'
+        self.set_query_param(action='txlist')
+        self.set_query_param(sort='desc')
 
-        self.build_url()
         req = self.connect()
         return req['result']
 
@@ -29,7 +27,5 @@ class Account(Client):
         self.url_dict[self.ACTION] = 'tokenbalance'
         self.url_dict[self.CONTRACT_ADDRESS] = contract_address
 
-        self.build_url()
-        print(self.url)
         req = self.connect()
         return req['result']

--- a/etherscan/client.py
+++ b/etherscan/client.py
@@ -5,43 +5,23 @@ import requests
 
 class Client():
 
-    PREFIX = 'https://api.etherscan.io/api?'
-    MODULE = '&module='
-    ACTION = '&action='
-    ADDRESS = '&address='
-    CONTRACT_ADDRESS = '&contractaddress='
-    SORT = '&sort='
-    TAG = '&tag='
-    API_KEY = '&apikey='
+    url = 'https://api.etherscan.io/api'
 
     def __init__(self, address, api_key = ''):
         # Allows persistent cookies.
         self.http = requests.session()
+        self.set_query_param(address=address, apikey=api_key)
 
-        # For constructing the URL.
-        self.url_dict = collections.OrderedDict([
-            (self.ADDRESS, address),
-            (self.CONTRACT_ADDRESS, ''),
-            (self.ACTION, ''),
-            (self.SORT, ''),
-            (self.TAG, ''),
-            (self.API_KEY, api_key),
-            ])
-
-        self.url = None
-
-
-    def build_url(self):
-        '''Creates a URL based on the values given to it in self.url_dict.'''
-        self.url = self.PREFIX + ''.join(
-            [param + val if val else '' for param, val in self.url_dict.items()]
-            )
+    def set_query_param(self, **kwargs):
+        """Sets the given query parameters."""
+        self.http.params.update(kwargs)
 
     def connect(self):
         try:
             request = self.http.get(self.url)
         except requests.exceptions.ConnectionError:
             print('Connection Refused')
+            return
 
         if request.status_code == 200:
             if request.text:
@@ -56,4 +36,4 @@ class Client():
 
 
     def show_api_key(self):
-        print(self.url_dict)
+        print(self.http.params)

--- a/etherscan/stats.py
+++ b/etherscan/stats.py
@@ -3,10 +3,10 @@ from .client import Client
 class Stats(Client):
     def __init__(self, address = '', api_key = ''):
         super().__init__(address, api_key = api_key)
-        self.url_dict[self.MODULE] = 'stats'
+        self.set_query_param(module='stats')
 
     def get_ether_last_price(self):
-        self.url_dict[self.ACTION] = 'ethprice'
-        self.build_url()
+        self.set_query_param(action='ethprice')
+
         req = self.connect()
         return req['result']


### PR DESCRIPTION
Use `params` attribute of `requests.Session()` instead of manually constructing the query parameters in the URL.