### PR TITLE
Only store persistent stuff in session

### DIFF
--- a/etherscan/account.py
+++ b/etherscan/account.py
@@ -9,23 +9,29 @@ class Account(Client):
 
     def get_balance(self) -> int:
         '''Get the latest balance on address.'''
-        self.set_query_param(action='balance')
-        self.set_query_param(tag='latest')
+        params = {
+            'action': 'balance',
+            'tag': 'latest',
+        }
 
-        req = self.connect()
+        req = self.connect(params=params)
         return req['result']
 
     def get_transaction_page(self) -> list:
         '''Get the latest transactions on address'''
-        self.set_query_param(action='txlist')
-        self.set_query_param(sort='desc')
+        params = {
+            'action': 'txlist',
+            'sort': 'desc',
+        }
 
-        req = self.connect()
+        req = self.connect(params=params)
         return req['result']
 
     def get_token_balance(self, contract_address):
-        self.set_query_param(action='tokenbalance')
-        self.set_query_param(contractaddress=contract_address)
+        params = {
+            'action': 'tokenbalance',
+            'contractaddress': contract_address,
+        }
 
-        req = self.connect()
+        req = self.connect(params=params)
         return req['result']

--- a/etherscan/client.py
+++ b/etherscan/client.py
@@ -1,6 +1,5 @@
 ''' Took https://github.com/corpetty/py-etherscan-api as a learning experience.'''
 
-import collections
 import requests
 
 class Client():
@@ -16,9 +15,9 @@ class Client():
         """Sets the given query parameters."""
         self.http.params.update(kwargs)
 
-    def connect(self):
+    def connect(self, params):
         try:
-            request = self.http.get(self.url)
+            request = self.http.get(self.url, params=params)
             print(request.url)
         except requests.exceptions.ConnectionError:
             print('Connection Refused')

--- a/etherscan/stats.py
+++ b/etherscan/stats.py
@@ -6,7 +6,9 @@ class Stats(Client):
         self.set_query_param(module='stats')
 
     def get_ether_last_price(self):
-        self.set_query_param(action='ethprice')
+        params = {
+            'action': 'ethprice',
+        }
 
-        req = self.connect()
+        req = self.connect(params=params)
         return req['result']


### PR DESCRIPTION
Don't store the things related to a specific request in the session object. Only things that are needed across requests, such as the api key.